### PR TITLE
replace compile with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This library is still in it's very early stages, but improvements would come ove
 ![Image of Library in action](http://res.cloudinary.com/duswj2lve/image/upload/v1479837904/chatui_k3diqq.png)
 
 ### Version
+
 v0.1.4
 
 ### Installation
@@ -28,18 +29,19 @@ Then add the dependency
 
 ```
 dependencies {
-	compile 'com.github.timigod:android-chat-ui:v0.1.4'
+	implementation 'com.github.timigod:android-chat-ui:v0.1.4'
 }
 ```
 
 ## Usage
+
 Drop the ChatView in your XML layout as is shown below:
 
 ```
 <co.intentservice.chatui.ChatView
 	android:id="@+id/chat_view"
 	android:layout_width="match_parent"
-	android:layout_height="match_parents"
+	android:layout_height="match_parent"
 	<!-- Insert customisation options here -->
 />
 ```
@@ -87,22 +89,21 @@ You can detect when a user clicks the "send" action button by using the `OnSentM
 chatView.setOnSentMessageListener(new ChatView.OnSentMessageListener(){
 	@Override
 	public boolean sendMessage(ChatMessage chatMessage){
-		// perform actual message sending 
+		// perform actual message sending
 		return true;
 	}
 });
 ```
 
-
-In the method `sendMessage()`, you can now perform whatever logic  to send messages i.e make an HTTP request or send the message over a socket connection. 
+In the method `sendMessage()`, you can now perform whatever logic to send messages i.e make an HTTP request or send the message over a socket connection.
 
 Depending on whatever logic or validation you put in place, you may return `true` or `false`. `true` will update the `ChatView` with the message bubble and `false` will do the opposite.
 
 ### Receiving messages
 
-You can use the `chatView.addMessage(ChatMessage message)` to add a "received" message to the UI. This obviously should be done after whatever mechanisms you have in place have actually received a message. 
+You can use the `chatView.addMessage(ChatMessage message)` to add a "received" message to the UI. This obviously should be done after whatever mechanisms you have in place have actually received a message.
 
-You can use this method or `chatView.addMessages(ArrayList<ChatMessage> messages)` to add messages to the UI. 
+You can use this method or `chatView.addMessages(ArrayList<ChatMessage> messages)` to add messages to the UI.
 
 The side the chat bubble will appear on is determined by the `Type` of the `ChatMessage`.
 
@@ -126,7 +127,7 @@ chatView.setTypingListener(new ChatView.TypingListener(){
 	public void userStartedTyping(){
 		// will be called when the user starts typing
 	}
-	
+
 	@Override
 	public void userStoppedTyping(){
 		// will be called when the user stops typing
@@ -135,14 +136,17 @@ chatView.setTypingListener(new ChatView.TypingListener(){
 ```
 
 ### TODO
+
 This is list of things that are in the works for this library:
 
 # Theming
+
 - message TextAppearance (sent / received messages)
 - timestamp TextAppearance (sent / received messages)
 - The ability to use an image as the background for the ChatView
 
 # Functionality
+
 - Ability to use custom item layout
 - Ability to send and recieve multimedia messages like images, embedded locations and even videos.
 - Ability to track and update individual messages (Useful to be able to show delivered/read/unread status or the like)
@@ -150,6 +154,7 @@ This is list of things that are in the works for this library:
 Of course, additions to this library aren't limited to the above.
 
 ### Contributing
+
 We welcome any and all contributions, code cleanups and feature requests.
 
 1. Check for open issues or open a fresh issue to start a discussion around a feature idea or a bug.


### PR DESCRIPTION
Android Studio reports that "configuration ‘compile’ is obsolete and has been replaced with ‘implementation’.". This update the installation instructions to use "implementation" instead.